### PR TITLE
Support json object expand.

### DIFF
--- a/operator.go
+++ b/operator.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/antonmedv/expr"
 	"github.com/fatih/color"
+	"github.com/goccy/go-json"
 	"github.com/goccy/go-yaml"
 	"github.com/hashicorp/go-multierror"
 	"github.com/k1LoW/expand"
@@ -840,6 +841,13 @@ func (o *operator) expand(in interface{}) (interface{}, error) {
 				s = strconv.Itoa(v)
 			case bool:
 				s = strconv.FormatBool(v)
+			case map[string]interface{}, []interface{}:
+				bytes, err := json.Marshal(v)
+				if err != nil {
+					reperr = fmt.Errorf("json.Marshal error: %w", err)
+				} else {
+					s = string(bytes)
+				}
 			default:
 				reperr = fmt.Errorf("invalid format: %v\n%s", o, string(b))
 			}

--- a/operator_test.go
+++ b/operator_test.go
@@ -76,6 +76,18 @@ func TestExpand(t *testing.T) {
 			map[string]string{"boolean": "{{ vars.boolean }}"},
 			map[string]interface{}{"boolean": true},
 		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"map": map[string]interface{}{"foo": "test", "bar": 1}},
+			map[string]string{"map": "{{ vars.map }}"},
+			map[string]interface{}{"map": map[string]interface{}{"foo": "test", "bar": uint64(1)}},
+		},
+		{
+			[]map[string]interface{}{},
+			map[string]interface{}{"array": []interface{}{map[string]interface{}{"foo": "test1", "bar": 1}, map[string]interface{}{"foo": "test2", "bar": 2}}},
+			map[string]string{"array": "{{ vars.array }}"},
+			map[string]interface{}{"array": []interface{}{map[string]interface{}{"foo": "test1", "bar": uint64(1)}, map[string]interface{}{"foo": "test2", "bar": uint64(2)}}},
+		},
 	}
 	for _, tt := range tests {
 		o, err := New()


### PR DESCRIPTION
T/O


# Testing

* yaml
  ```yml
  desc: testing json request body
  runners:
    req:
      endpoint: ${ENDPOINT:-https://httpbin.org/}
  debug: ${DEBUG:-true}
  vars:
    jsonRequestBody:
      foo: "test"
      bar: 1
    arrayJsonRequestBody:
      -
        foo: "test1"
        bar: 1
      -
        foo: "test2"
        bar: 2
  steps:
    -
      req:
        /post:
          post:
            body:
              application/json: "{{ vars.jsonRequestBody }}"
    -
      test: |
        steps[0].res.status == 200
      #  && steps[0].res.body.json == vars.jsonRequestBody # FIXME: Need assert.Equal
    -
      req:
        /put:
          put:
            body:
              application/json: "{{ vars.arrayJsonRequestBody }}"
    -
      test: |
        steps[2].res.status == 200
      # && steps[2].res.body.json == vars.arrayJsonRequestBody # FIXME: Need assert.Equal
  ```
* Execution log
  ```log
  Run 'req' on 'testing json request body'.steps[0]
  -----START HTTP REQUEST-----
  POST /post HTTP/1.1
  Host: localhost
  Content-Type: application/json
  
  {"bar":1,"foo":"test"}
  -----END HTTP REQUEST-----
  -----START HTTP RESPONSE-----
  HTTP/1.1 200 OK
  Content-Length: 392
  Access-Control-Allow-Credentials: true
  Access-Control-Allow-Origin: *
  Connection: keep-alive
  Content-Type: application/json
  Date: Fri, 12 Aug 2022 01:02:56 GMT
  Server: gunicorn/19.9.0
  
  {
    "args": {}, 
    "data": "{\"bar\":1,\"foo\":\"test\"}", 
    "files": {}, 
    "form": {}, 
    "headers": {
      "Accept-Encoding": "gzip", 
      "Content-Length": "22", 
      "Content-Type": "application/json", 
      "Host": "localhost", 
      "User-Agent": "Go-http-client/1.1"
    }, 
    "json": {
      "bar": 1, 
      "foo": "test"
    }, 
    "origin": "172.17.0.1", 
    "url": "http://localhost/post"
  }
  
  -----END HTTP RESPONSE-----
  
  Run 'test' on 'testing json request body'.steps[1]
  -----START TEST CONDITION-----
  steps[0].res.status == 200
  
  ├── steps[0].res.status => 200
  └── 200 => 200
  -----END TEST CONDITION-----
  
  Run 'req' on 'testing json request body'.steps[2]
  -----START HTTP REQUEST-----
  PUT /put HTTP/1.1
  Host: localhost
  Content-Type: application/json
  
  [{"bar":1,"foo":"test1"},{"bar":2,"foo":"test2"}]
  -----END HTTP REQUEST-----
  -----START HTTP RESPONSE-----
  HTTP/1.1 200 OK
  Content-Length: 493
  Access-Control-Allow-Credentials: true
  Access-Control-Allow-Origin: *
  Connection: keep-alive
  Content-Type: application/json
  Date: Fri, 12 Aug 2022 01:02:56 GMT
  Server: gunicorn/19.9.0
  
  {
    "args": {}, 
    "data": "[{\"bar\":1,\"foo\":\"test1\"},{\"bar\":2,\"foo\":\"test2\"}]", 
    "files": {}, 
    "form": {}, 
    "headers": {
      "Accept-Encoding": "gzip", 
      "Content-Length": "49", 
      "Content-Type": "application/json", 
      "Host": "localhost", 
      "User-Agent": "Go-http-client/1.1"
    }, 
    "json": [
      {
        "bar": 1, 
        "foo": "test1"
      }, 
      {
        "bar": 2, 
        "foo": "test2"
      }
    ], 
    "origin": "172.17.0.1", 
    "url": "http://localhost/put"
  }
  
  -----END HTTP RESPONSE-----
  
  Run 'test' on 'testing json request body'.steps[3]
  -----START TEST CONDITION-----
  steps[2].res.status == 200
  
  ├── steps[2].res.status => 200
  └── 200 => 200
  -----END TEST CONDITION-----
  testing json request body ... ok
  
  1 scenario, 0 skipped, 0 failures
  ```
